### PR TITLE
Allow relations to return a single object

### DIFF
--- a/src/Framework/Rest/Entity.php
+++ b/src/Framework/Rest/Entity.php
@@ -105,20 +105,24 @@ class Entity implements EntityInterface
         return $this->data;
     }
 
-    public function addEmbedded(string $type, EntityInterface $entity): EntityInterface
+    public function addEmbedded(string $type, EntityInterface $entity, bool $collection = true): EntityInterface
     {
         $self = clone $this;
-        if (!array_key_exists($type, $self->embedded)) {
-            $self->embedded[$type] = [];
+        if (!$collection) {
+            $self->embedded[$type] = $entity;
+        } else {
+            if (!is_array($self->embedded[$type])) {
+                $self->embedded[$type] = [$entity];
+            } else {
+                $self->embedded[$type][] = $entity;
+            }
         }
-
-        $self->embedded[$type][] = $entity;
 
         return $self;
     }
 
     /**
-     * @return Entity[][]
+     * @return EntityInterface[][]|EntityInterface[]
      */
     public function getEmbedded(): array
     {

--- a/src/Framework/Rest/Serializers/HalJsonSerializer.php
+++ b/src/Framework/Rest/Serializers/HalJsonSerializer.php
@@ -76,7 +76,12 @@ class HalJsonSerializer extends PlainJsonSerializer
                 $payload['_embedded'] = [];
             }
 
-            $payload['_embedded'][$rel] = array_map([$this, 'convert'], $values);
+            if (is_array($values)) {
+                $payload['_embedded'][$rel] = array_map([$this, 'convert'], $values);
+                continue;
+            }
+
+            $payload['_embedded'][$rel] = [$this->convert($values)];
         }
 
         return $payload;

--- a/src/Framework/Rest/Serializers/JsonApiSerializer.php
+++ b/src/Framework/Rest/Serializers/JsonApiSerializer.php
@@ -107,7 +107,11 @@ class JsonApiSerializer extends PlainJsonSerializer
                 $payload['data']['relationships'][$rel] = [];
             }
 
-            $embeds = array_map([$this, 'convert'], $values);
+            if (is_array($values)) {
+                $embeds = array_map([$this, 'convert'], $values);
+            } else {
+                $embeds = [$this->convert($values)];
+            }
 
             $payload['data']['relationships'][$rel][] = [
                 'links' => $embeds[0]['links'],

--- a/src/Framework/Rest/Serializers/JsonLdSerializer.php
+++ b/src/Framework/Rest/Serializers/JsonLdSerializer.php
@@ -45,7 +45,7 @@ class JsonLdSerializer extends PlainJsonSerializer
         if (count($meta) === 1) {
             $payload['@context'] = array_pop($meta);
         } else {
-            $payload['@context'] = array_filter($meta, function ($index) {
+            $payload['@context'] = array_filter($meta, function ($index) use ($entity) {
                 if (strpos($index, '@') === 0) {
                     return in_array($index, ['@vocab', '@base'], true);
                 }
@@ -57,7 +57,12 @@ class JsonLdSerializer extends PlainJsonSerializer
         $entity = $entity->withoutDataItem('id');
 
         foreach ($entity->getEmbedded() as $rel => $embed) {
-            $payload[$rel] = array_map([$this, 'convert'], $embed);
+            if (is_array($embed)) {
+                $payload[$rel] = array_map([$this, 'convert'], $embed);
+                continue;
+            }
+
+            $payload[$rel] = $embed;
         }
 
         return array_merge($payload, $entity->getData());

--- a/src/Framework/Rest/Serializers/PlainJsonSerializer.php
+++ b/src/Framework/Rest/Serializers/PlainJsonSerializer.php
@@ -20,7 +20,19 @@ class PlainJsonSerializer implements SerializerInterface
 
     protected function convert(Entity $entity): array
     {
-        return $entity->getData();
+        $data = $entity->getData();
+        foreach ($entity->getEmbedded() as $rel => $relation) {
+            if (!isset($data[$rel])) {
+                if (is_array($relation)) {
+                    $payload[$rel] = array_map([$this, 'convert'], $relation);
+                    continue;
+                }
+
+                $data[$rel] = $this->convert($relation);
+            }
+        }
+
+        return $data;
     }
 
     public function serialize(Entity $entity): string

--- a/src/Framework/Rest/Transformer.php
+++ b/src/Framework/Rest/Transformer.php
@@ -54,13 +54,20 @@ class Transformer implements TransformerInterface
                 $result = $hydratableInterface->{$method}();
                 if (is_array($result)) {
                     foreach ($result as $embedded) {
-                        $entity = $entity->addEmbedded($relation, $this->transform($embedded, $includes, $fields));
+                        $entity = $entity->addEmbedded(
+                            $relation,
+                            $this->transform($embedded, $includes, $fields),
+                            true
+                        );
                     }
-
                     continue;
                 }
 
-                $entity = $entity->addEmbedded($relation, $this->transform($result, $includes, $fields));
+                $entity = $entity->addEmbedded(
+                    $relation,
+                    $this->transform($result, $includes, $fields),
+                    false
+                );
             }
         }
 


### PR DESCRIPTION
Allowing this can clearly make the JSON responses more robust and meaningful for relations where there will always be a 1-to-1 relationship so that it is not pushed as an array